### PR TITLE
Fix 9: Live stream playing pauses after 5 seconds (without any errors in console) 🛠️ 🔴 

### DIFF
--- a/src/services/playSong.ts
+++ b/src/services/playSong.ts
@@ -18,7 +18,7 @@ export const playSong = (queueConstruct: QueueConstructs, message: Message) => {
   const options: DownloadOptions = songToPlay.isLive
     ? {
         highWaterMark: 1 << 25,
-        liveBuffer: 40000,
+        liveBuffer: 4900,
       }
     : {
         quality: 'highestaudio',


### PR DESCRIPTION
 - fix(services/play): changed live buffer size for live streams